### PR TITLE
areaSize is an Editor-only property, which causes an error when building

### DIFF
--- a/Runtime/Lighting/AdditionalLightData.cs
+++ b/Runtime/Lighting/AdditionalLightData.cs
@@ -561,6 +561,7 @@ namespace UnityEngine.Rendering.Universal
                     lightData.lightUnit = LightUnit.Lux;
                     lightData.intensity = k_DefaultDirectionalLightIntensity / Mathf.PI * 100000.0f; // Change back to just k_DefaultDirectionalLightIntensity on 11.0.0 (can't change constant as it's a breaking change)
                     break;
+#if UNITY_EDITOR
                 case LightType.Area: // Rectangle by default when light is created
                     switch (lightData.legacyLight.type)
                     {
@@ -576,6 +577,7 @@ namespace UnityEngine.Rendering.Universal
                             break;
                     }
                     break;
+#endif // UNITY_EDITOR
                 case LightType.Point:
                 case LightType.Spot:
                     lightData.lightUnit = LightUnit.Lumen;
@@ -654,8 +656,10 @@ namespace UnityEngine.Rendering.Universal
                 // if (m_PointlightHDType == PointLightHDType.Punctual)
                 if (legacyLight.type != LightType.Area )
                     SetLightIntensityPunctual(intensity);
+#if UNITY_EDITOR
                 else
                     legacyLight.intensity = LightUtils.ConvertAreaLightLumenToLuminance(legacyLight.type, intensity, legacyLight.areaSize.x, legacyLight.areaSize.y);
+#endif // UNITY_EDITOR
             }
             else if (lightUnit == LightUnit.Ev100)
             {

--- a/Runtime/Lighting/LightUtils.cs
+++ b/Runtime/Lighting/LightUtils.cs
@@ -504,6 +504,7 @@ namespace UnityEngine.Rendering.Universal
                 else if (oldLightUnit == LightUnit.Ev100 && newLightUnit == LightUnit.Lux)
                     intensity = LightUtils.ConvertEvToLux(intensity, hdLight.luxAtDistance);
             }
+#if UNITY_EDITOR
             else  // For area lights
             {
                 if (oldLightUnit == LightUnit.Lumen && newLightUnit == LightUnit.Nits)
@@ -519,6 +520,7 @@ namespace UnityEngine.Rendering.Universal
                 if (oldLightUnit == LightUnit.Lumen && newLightUnit == LightUnit.Ev100)
                     intensity = LightUtils.ConvertAreaLightLumenToEv(lightType, intensity, hdLight.legacyLight.areaSize.x, hdLight.legacyLight.areaSize.y);
             }
+#endif // UNITY_EDITOR
 
             hdLight.intensity = intensity;
         }


### PR DESCRIPTION
### Purpose of this PR
Accessing the areaSize property of a Light prevents a project with this package from being built.
This PR ensures that this property is not referenced outside of the editor.

```
//
// Summary:
//     The size of the area light (Editor only).
public Vector2 areaSize
```

---
### Testing status
Projects using this package can now be built successfully.
Tested on Windows 10, Windows 11 and Android 14.

---
### Comments to reviewers